### PR TITLE
Stick a link to the discourse thread at the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # FemtoCleaner
+[How to use FemotoCleaner to update packages for julia 0.7](https://discourse.julialang.org/t/femtocleaner-usage-howto/11762)
+
 
 <p align="center"><img src="https://media.giphy.com/media/uVOTDhb5O5nW0/giphy.gif" alt="serious femtocleaning"></p>
 


### PR DESCRIPTION
I suggest that the thing that most people want to know when they come to this page is the stuff on the discourse thread.
So linking that at the top seems like a good idea